### PR TITLE
Register an entry point when installing package

### DIFF
--- a/ipfromwebpage/ipfromwebpage.py
+++ b/ipfromwebpage/ipfromwebpage.py
@@ -100,6 +100,10 @@ def main(url):
         print("No ips found when scraping {}".format(url))
 
 
-if __name__ == '__main__':
+def entrypoint():
     url = check_args(sys.argv[1:]).url
     main(url)
+
+
+if __name__ == '__main__':
+    entrypoint()

--- a/setup.py
+++ b/setup.py
@@ -45,5 +45,11 @@ setup(
     ],
     test_suite='tests',
     tests_require=test_requirements,
-    setup_requires=setup_requirements
+    setup_requires=setup_requirements,
+
+    entry_points={
+        'console_scripts': [
+            'ipfromwebpage = ipfromwebpage.ipfromwebpage:entrypoint',
+        ],
+    },
 )


### PR DESCRIPTION
This means `ipfromwebpage` will be registered inside `$PATH` when installed.

Fixes #9.